### PR TITLE
refactor: add optonal null's and type CodeChallengeMethod

### DIFF
--- a/docs/entities/README.md
+++ b/docs/entities/README.md
@@ -35,13 +35,20 @@ interface OAuthAuthCode {
   code: string;
   redirectUri?: string;
   codeChallenge?: string;
-  codeChallengeMethod?: string;
+  codeChallengeMethod?: CodeChallengeMethod;
   expiresAt: Date;
   user?: OAuthUser;
   client: OAuthClient;
   scopes: OAuthScope[];
 }
 ```
+
+::: tip
+
+```ts
+type CodeChallengeMethod = "s256" | "plain";
+```
+:::
 
 ## Token Entity
 

--- a/examples/typeorm_express/src/entities/auth_code.ts
+++ b/examples/typeorm_express/src/entities/auth_code.ts
@@ -8,7 +8,7 @@ import {
   ManyToOne, PrimaryColumn,
 } from "typeorm";
 
-import { OAuthAuthCode } from "../../../../src";
+import { CodeChallengeMethod, OAuthAuthCode } from "../../../../src";
 import { Client } from "./client";
 import { Scope } from "./scope";
 import { User } from "./user";
@@ -46,7 +46,7 @@ export class AuthCode implements OAuthAuthCode {
   @Column("varchar", { nullable: true, length: 128 })
   // @IsOptional()
   // @IsIn(["s256", "plain"])
-  codeChallengeMethod?: string;
+  codeChallengeMethod?: CodeChallengeMethod;
 
   @Column()
   expiresAt!: Date;

--- a/src/authorization_server.ts
+++ b/src/authorization_server.ts
@@ -26,48 +26,7 @@ export class AuthorizationServer {
   private readonly enabledGrantTypes: { [key: string]: GrantInterface } = {};
   private readonly grantTypeAccessTokenTTL: { [key: string]: DateInterval } = {};
 
-  private readonly availableGrants: { [key in GrantIdentifier]: GrantInterface } = {
-    authorization_code: new AuthCodeGrant(
-      this.authCodeRepository,
-      this.clientRepository,
-      this.tokenRepository,
-      this.scopeRepository,
-      this.userRepository,
-      this.jwt,
-    ),
-    client_credentials: new ClientCredentialsGrant(
-      this.authCodeRepository,
-      this.clientRepository,
-      this.tokenRepository,
-      this.scopeRepository,
-      this.userRepository,
-      this.jwt,
-    ),
-    implicit: new ImplicitGrant(
-      this.authCodeRepository,
-      this.clientRepository,
-      this.tokenRepository,
-      this.scopeRepository,
-      this.userRepository,
-      this.jwt,
-    ),
-    password: new PasswordGrant(
-      this.authCodeRepository,
-      this.clientRepository,
-      this.tokenRepository,
-      this.scopeRepository,
-      this.userRepository,
-      this.jwt,
-    ),
-    refresh_token: new RefreshTokenGrant(
-      this.authCodeRepository,
-      this.clientRepository,
-      this.tokenRepository,
-      this.scopeRepository,
-      this.userRepository,
-      this.jwt,
-    ),
-  };
+  private readonly availableGrants: { [key in GrantIdentifier]: GrantInterface };
 
   private options: AuthorizationServerOptions = {
     requiresPKCE: true,
@@ -83,6 +42,28 @@ export class AuthorizationServer {
     options?: Partial<AuthorizationServerOptions>,
   ) {
     this.setOptions(options);
+    const repos: [
+      OAuthAuthCodeRepository,
+      OAuthClientRepository,
+      OAuthTokenRepository,
+      OAuthScopeRepository,
+      OAuthUserRepository,
+      JwtInterface,
+    ] = [
+      this.authCodeRepository,
+      this.clientRepository,
+      this.tokenRepository,
+      this.scopeRepository,
+      this.userRepository,
+      this.jwt,
+    ];
+    this.availableGrants = {
+      authorization_code: new AuthCodeGrant(...repos),
+      client_credentials: new ClientCredentialsGrant(...repos),
+      implicit: new ImplicitGrant(...repos),
+      password: new PasswordGrant(...repos),
+      refresh_token: new RefreshTokenGrant(...repos),
+    }
   }
 
   setOptions(options: Partial<AuthorizationServerOptions> = {}) {

--- a/src/authorization_server.ts
+++ b/src/authorization_server.ts
@@ -63,19 +63,19 @@ export class AuthorizationServer {
       implicit: new ImplicitGrant(...repos),
       password: new PasswordGrant(...repos),
       refresh_token: new RefreshTokenGrant(...repos),
-    }
+    };
   }
 
   setOptions(options: Partial<AuthorizationServerOptions> = {}) {
-    this.options = { ...this.options, ...options, };
+    this.options = { ...this.options, ...options };
   }
 
   enableGrantTypes(...grants: EnableGrantTuple[]) {
-    grants.forEach((grant) => {
+    grants.forEach(grant => {
       if (typeof grant === "string") return this.enableGrantType(grant);
       const [grantType, accessTokenTTL] = grant;
-      this.enableGrantType(grantType, accessTokenTTL)
-    })
+      this.enableGrantType(grantType, accessTokenTTL);
+    });
   }
 
   enableGrantType(grantType: GrantIdentifier, accessTokenTTL: DateInterval = new DateInterval("1h")): void {

--- a/src/code_verifiers/s256.verifier.ts
+++ b/src/code_verifiers/s256.verifier.ts
@@ -4,7 +4,7 @@ import { base64urlencode } from "../utils/base64";
 import { ICodeChallenge } from "./verifier";
 
 export class S256Verifier implements ICodeChallenge {
-  public readonly method = "S256";
+  public readonly method = "s256";
 
   verifyCodeChallenge(codeVerifier: string, codeChallenge: string): boolean {
     const codeHash = crypto

--- a/src/code_verifiers/verifier.ts
+++ b/src/code_verifiers/verifier.ts
@@ -1,4 +1,4 @@
-export type CodeChallengeMethod = "S256" | "plain";
+export type CodeChallengeMethod = "s256" | "plain";
 
 export interface ICodeChallenge {
   method: CodeChallengeMethod;

--- a/src/entities/auth_code.entity.ts
+++ b/src/entities/auth_code.entity.ts
@@ -1,14 +1,15 @@
+import { CodeChallengeMethod } from "../code_verifiers/verifier";
 import { OAuthClient } from "./client.entity";
 import { OAuthScope } from "./scope.entity";
 import { OAuthUser } from "./user.entity";
 
 export interface OAuthAuthCode {
   code: string;
-  redirectUri?: string;
-  codeChallenge?: string;
-  codeChallengeMethod?: string;
+  redirectUri?: string | null;
+  codeChallenge?: string | null;
+  codeChallengeMethod?: CodeChallengeMethod | null;
   expiresAt: Date;
-  user?: OAuthUser;
+  user?: OAuthUser | null;
   client: OAuthClient;
   scopes: OAuthScope[];
 }

--- a/src/entities/client.entity.ts
+++ b/src/entities/client.entity.ts
@@ -4,7 +4,7 @@ import { OAuthScope } from "./scope.entity";
 export interface OAuthClient {
   id: string;
   name: string;
-  secret?: string;
+  secret?: string | null;
   redirectUris: string[];
   allowedGrants: GrantIdentifier[];
   scopes: OAuthScope[];

--- a/src/entities/token.entity.ts
+++ b/src/entities/token.entity.ts
@@ -5,9 +5,9 @@ import { OAuthUser } from "./user.entity";
 export interface OAuthToken {
   accessToken: string;
   accessTokenExpiresAt: Date;
-  refreshToken?: string;
-  refreshTokenExpiresAt?: Date;
+  refreshToken?: string | null;
+  refreshTokenExpiresAt?: Date | null;
   client: OAuthClient;
-  user?: OAuthUser;
+  user?: OAuthUser | null;
   scopes: OAuthScope[];
 }

--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -216,7 +216,7 @@ export abstract class AbstractGrant implements GrantInterface {
   protected async issueAccessToken(
     accessTokenTTL: DateInterval,
     client: OAuthClient,
-    user?: OAuthUser,
+    user?: OAuthUser | null,
     scopes: OAuthScope[] = [],
   ): Promise<OAuthToken> {
     const accessToken = await this.tokenRepository.issueToken(client, scopes, user);

--- a/src/grants/auth_code.grant.ts
+++ b/src/grants/auth_code.grant.ts
@@ -9,7 +9,6 @@ import { AuthorizationRequest } from "../requests/authorization.request";
 import { RequestInterface } from "../requests/request";
 import { RedirectResponse } from "../responses/redirect.response";
 import { ResponseInterface } from "../responses/response";
-import { base64decode } from "../utils/base64";
 import { DateInterval } from "../utils/date_interval";
 import { AbstractAuthorizedGrant } from "./abstract/abstract_authorized.grant";
 import { GrantIdentifier } from "./abstract/grant.interface";
@@ -19,10 +18,10 @@ export interface IAuthCodePayload {
   auth_code_id: string;
   expire_time: number;
   scopes: string[];
-  user_id?: string;
-  redirect_uri?: string;
-  code_challenge?: string;
-  code_challenge_method?: string;
+  user_id?: string | null;
+  redirect_uri?: string | null;
+  code_challenge?: string | null;
+  code_challenge_method?: CodeChallengeMethod | null;
 }
 
 export const REGEXP_CODE_VERIFIER = /^[A-Za-z0-9-._~]{43,128}$/;

--- a/src/repositories/access_token.repository.ts
+++ b/src/repositories/access_token.repository.ts
@@ -4,7 +4,7 @@ import { OAuthToken } from "../entities/token.entity";
 import { OAuthUser } from "../entities/user.entity";
 
 export interface OAuthTokenRepository {
-  issueToken(client: OAuthClient, scopes: OAuthScope[], user?: OAuthUser): Promise<OAuthToken>;
+  issueToken(client: OAuthClient, scopes: OAuthScope[], user?: OAuthUser | null): Promise<OAuthToken>;
 
   issueRefreshToken(accessToken: OAuthToken): Promise<OAuthToken>;
 

--- a/src/requests/authorization.request.ts
+++ b/src/requests/authorization.request.ts
@@ -1,3 +1,4 @@
+import { CodeChallengeMethod } from "../code_verifiers/verifier";
 import { OAuthClient } from "../entities/client.entity";
 import { OAuthScope } from "../entities/scope.entity";
 import { OAuthUser } from "../entities/user.entity";
@@ -10,7 +11,7 @@ export class AuthorizationRequest {
   redirectUri: string | undefined;
   state?: string;
   codeChallenge?: string;
-  codeChallengeMethod?: string;
+  codeChallengeMethod?: CodeChallengeMethod;
 
   constructor(
     public readonly grantTypeId: GrantIdentifier,

--- a/test/e2e/auth_code.grant.e2e-spec.ts
+++ b/test/e2e/auth_code.grant.e2e-spec.ts
@@ -42,7 +42,7 @@ describe.skip("auth_code grant e2e", () => {
         scope: "scope-1 scope-2",
         state: "state-is-a-secret",
         code_challenge: codeChallenge,
-        code_challenge_method: "S256",
+        code_challenge_method: "s256",
       });
 
     const authorizeResponseQuery = querystring.parse(authorizeResponse.headers.location);

--- a/test/unit/authorization_server.spec.ts
+++ b/test/unit/authorization_server.spec.ts
@@ -111,7 +111,7 @@ describe("authorization_server", () => {
         scope: "scope-1 scope-2",
         state: "state-is-a-secret",
         code_challenge: codeChallenge,
-        code_challenge_method: "S256",
+        code_challenge_method: "s256",
       },
     });
     const authorizationRequest = await authorizationServer.validateAuthorizationRequest(request);
@@ -122,7 +122,7 @@ describe("authorization_server", () => {
     expect(authorizationRequest.redirectUri).toBe("http://localhost");
     expect(authorizationRequest.state).toBe("state-is-a-secret");
     expect(authorizationRequest.codeChallenge).toBe(codeChallenge);
-    expect(authorizationRequest.codeChallengeMethod).toBe("S256");
+    expect(authorizationRequest.codeChallengeMethod).toBe("s256");
     expect(authorizationRequest.scopes).toStrictEqual([scope1, scope2]);
   });
 
@@ -139,7 +139,7 @@ describe("authorization_server", () => {
 
     const authorizationRequest = new AuthorizationRequest("authorization_code", client, "http://localhost");
     authorizationRequest.isAuthorizationApproved = true;
-    authorizationRequest.codeChallengeMethod = "S256";
+    authorizationRequest.codeChallengeMethod = "s256";
     authorizationRequest.codeChallenge = codeChallenge;
     authorizationRequest.user = user;
 

--- a/test/unit/grants/auth_code.grant.spec.ts
+++ b/test/unit/grants/auth_code.grant.spec.ts
@@ -12,11 +12,7 @@ import {
 import { OAuthScope } from "../../../src/entities/scope.entity";
 import { OAuthUser } from "../../../src/entities/user.entity";
 import { OAuthClient } from "../../../src/entities/client.entity";
-import {
-  AuthCodeGrant,
-  IAuthCodePayload,
-  REGEX_ACCESS_TOKEN,
-} from "../../../src/grants/auth_code.grant";
+import { AuthCodeGrant, IAuthCodePayload, REGEX_ACCESS_TOKEN } from "../../../src/grants/auth_code.grant";
 import { AuthorizationRequest } from "../../../src/requests/authorization.request";
 import { OAuthRequest } from "../../../src/requests/request";
 import { OAuthResponse } from "../../../src/responses/response";

--- a/test/unit/grants/auth_code.grant.spec.ts
+++ b/test/unit/grants/auth_code.grant.spec.ts
@@ -77,7 +77,7 @@ describe("authorization_code grant", () => {
         redirect_uri: "http://example.com",
         state: "state-is-a-secret",
         code_challenge: codeChallenge,
-        code_challenge_method: "S256",
+        code_challenge_method: "s256",
       };
     });
 
@@ -120,7 +120,7 @@ describe("authorization_code grant", () => {
           redirect_uri: ["http://example.com"],
           state: "state-is-a-secret",
           code_challenge: codeChallenge,
-          code_challenge_method: "S256",
+          code_challenge_method: "s256",
         },
       });
       const authorizationRequest = await grant.validateAuthorizationRequest(request);
@@ -131,7 +131,7 @@ describe("authorization_code grant", () => {
       expect(authorizationRequest.redirectUri).toBe("http://example.com");
       expect(authorizationRequest.state).toBe("state-is-a-secret");
       expect(authorizationRequest.codeChallenge).toBe(codeChallenge);
-      expect(authorizationRequest.codeChallengeMethod).toBe("S256");
+      expect(authorizationRequest.codeChallengeMethod).toBe("s256");
       expect(authorizationRequest.scopes).toStrictEqual([]);
     });
 
@@ -226,7 +226,7 @@ describe("authorization_code grant", () => {
           redirect_uri: "http://example.com",
           state: "state-is-a-secret",
           code_challenge: "invalid-format(with!Invalid~characters",
-          code_challenge_method: "S256",
+          code_challenge_method: "s256",
         },
       });
       const authorizationRequest = grant.validateAuthorizationRequest(request);
@@ -282,7 +282,7 @@ describe("authorization_code grant", () => {
     it("is successful", async () => {
       const authorizationRequest = new AuthorizationRequest("authorization_code", client, "http://example.com");
       authorizationRequest.isAuthorizationApproved = true;
-      authorizationRequest.codeChallengeMethod = "S256";
+      authorizationRequest.codeChallengeMethod = "s256";
       authorizationRequest.codeChallenge = codeChallenge;
       authorizationRequest.state = "abc123";
       authorizationRequest.user = user;
@@ -305,7 +305,7 @@ describe("authorization_code grant", () => {
         "http://example.com?this_should_work=true",
       );
       authorizationRequest.isAuthorizationApproved = true;
-      authorizationRequest.codeChallengeMethod = "S256";
+      authorizationRequest.codeChallengeMethod = "s256";
       authorizationRequest.codeChallenge = codeChallenge;
       authorizationRequest.state = "abc123";
       authorizationRequest.user = user;
@@ -343,7 +343,7 @@ describe("authorization_code grant", () => {
     beforeEach(async () => {
       authorizationRequest = new AuthorizationRequest("authorization_code", client, "http://example.com");
       authorizationRequest.isAuthorizationApproved = true;
-      authorizationRequest.codeChallengeMethod = "S256";
+      authorizationRequest.codeChallengeMethod = "s256";
       authorizationRequest.codeChallenge = codeChallenge;
       authorizationRequest.user = user;
       const redirectResponse = await grant.completeAuthorizationRequest(authorizationRequest);


### PR DESCRIPTION
This introduces a slight breaking change in the OAuthAuthCode entity by adding a strict type for the codeChallengeMethod. See the following:

```ts
// before
export interface OAuthAuthCode {
  codeChallengeMethod?: string;
  ...
}

// after
export interface OAuthAuthCode {
  codeChallengeMethod?: CodeChallengeMethod;
  ...
}
```

The CodeChallengeMethod is the following

```ts
type CodeChallengeMethod = "s256" | "plain"
```

In addition to this, all optional fields on entities are now also supporting null values. I decided to add this in order to support Prisma entities. I hope this wasnt a bad choice...